### PR TITLE
Add model method that brakeman 5.1.2 won't parse

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,5 @@
 class Comment < ApplicationRecord
   belongs_to :article
+
+  def self.iam = 'thatis'
 end


### PR DESCRIPTION
Add an endless method that can't be parsed by `ruby_parser` `3.18.0`

This is an example for presidentbeef/brakeman#1652