### PR TITLE
Fail on brakeman error

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: brakeman
-        uses: reviewdog/action-brakeman@v1
+        uses: dgholz/action-brakeman@master
         with:
           brakeman_version: gemfile
           level: info

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,5 @@
 class Comment < ApplicationRecord
   belongs_to :article
+
+  def self.iam = 'thatis'
 end


### PR DESCRIPTION
This branch fails on Brakeman failing to parse the endless method in the Comments model. Both checks (Reviewdog and bare Brakeman) fail, hooray!

This is an example for reviewdog/action-brakeman#28